### PR TITLE
Add config variable for reporterEndpoint

### DIFF
--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -30,6 +30,7 @@ tracingEnabled=true
 tracingProvider="zipkin"
 
 [ballerinax.zipkin]
+reporterEndpoint="<TRACE_API>"  # Optional Configuration. This will override the values of agentHostname & agentPort.
 agentHostname="127.0.0.1"  # Optional Configuration. Default value is localhost
 agentPort=9411             # Optional Configuration. Default value is 9411
 ```

--- a/ballerina/tracer_provider.bal
+++ b/ballerina/tracer_provider.bal
@@ -21,6 +21,7 @@ import ballerina/observe;
 const PROVIDER_NAME = "zipkin";
 const DEFAULT_SAMPLER_TYPE = "const";
 
+configurable string reporterEndpoint = "";
 configurable string agentHostname = "localhost";
 configurable int agentPort = 9411;
 configurable string samplerType = "const";
@@ -39,12 +40,12 @@ function init() {
             selectedSamplerType = samplerType;
         }
 
-        externInitializeConfigurations(agentHostname, agentPort, selectedSamplerType, samplerParam,
+        externInitializeConfigurations(reporterEndpoint, agentHostname, agentPort, selectedSamplerType, samplerParam,
             reporterFlushInterval, reporterBufferSize);
     }
 }
 
-function externInitializeConfigurations(string agentHostname, int agentPort, string samplerType,
+function externInitializeConfigurations(string reporterEndpoint, string agentHostname, int agentPort, string samplerType,
         decimal samplerParam, int reporterFlushInterval, int reporterBufferSize) = @java:Method {
     'class: "io.ballerina.observe.trace.zipkin.ZipkinTracerProvider",
     name: "initializeConfigurations"

--- a/native/src/main/java/io/ballerina/observe/trace/zipkin/ZipkinTracerProvider.java
+++ b/native/src/main/java/io/ballerina/observe/trace/zipkin/ZipkinTracerProvider.java
@@ -33,6 +33,7 @@ import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 
 import java.io.PrintStream;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
@@ -56,12 +57,17 @@ public class ZipkinTracerProvider implements TracerProvider {
     public void init() {    // Do Nothing
     }
 
-    public static void initializeConfigurations(BString agentHostname, int agentPort, BString samplerType,
-                                                BDecimal samplerParam, int reporterFlushInterval,
+    public static void initializeConfigurations(BString reporterEndpointUrl, BString agentHostname, int agentPort,
+                                                BString samplerType, BDecimal samplerParam, int reporterFlushInterval,
                                                 int reporterBufferSize) {
 
-        String reporterEndpoint = APPLICATION_LAYER_PROTOCOL + "://" +
-                agentHostname + ":" + agentPort + "/api/v2/spans";
+        String reporterEndpoint;
+        if (!Objects.equals(String.valueOf(reporterEndpointUrl), "")) {
+            reporterEndpoint = String.valueOf(reporterEndpointUrl);
+        } else {
+            reporterEndpoint = APPLICATION_LAYER_PROTOCOL + "://" +
+                    agentHostname + ":" + agentPort + "/api/v2/spans";
+        }
 
         ZipkinSpanExporter exporter = ZipkinSpanExporter.builder().setEndpoint(reporterEndpoint).build();
 
@@ -74,7 +80,7 @@ public class ZipkinTracerProvider implements TracerProvider {
 
         tracerProviderBuilder.setSampler(selectSampler(samplerType, samplerParam));
 
-        console.println("ballerina: started publishing traces to Zipkin on " + reporterEndpoint);
+        console.println("ballerina: started publishing traces to Zipkin on " + reporterEndpoint.split("\\?")[0]);
     }
 
     private static Sampler selectSampler(BString samplerType, BDecimal samplerParam) {


### PR DESCRIPTION
## Purpose
This will enable the option for users to configure `reporter endpoint (TRACE API)` instead of passing the `agent hostname` & `host port`. 

If the user configures the `reporterEndpoint` in `Config.toml`, it will override the `agent hostname` & `host port` even if we configure them.
