### PR TITLE
Protect trace API token by passing it through an environment variable

### DIFF
--- a/ballerina-tests/zipkin-server-tests/tests/test.bal
+++ b/ballerina-tests/zipkin-server-tests/tests/test.bal
@@ -378,7 +378,7 @@ function testHttpCachingClientSpanTags() returns error? {
     test:assertTrue(containsTag("src.function.name", httpCachingClientSpanTagKeys));
     test:assertEquals(httpCachingClientSpanTags["src.function.name"], "get");
     test:assertTrue(containsTag("src.module", httpCachingClientSpanTagKeys));
-    test:assertEquals(httpCachingClientSpanTags["src.module"], "ballerina/http:2.10.0");
+    test:assertEquals(httpCachingClientSpanTags["src.module"], "ballerina/http:2.10.1");
     test:assertTrue(containsTag("src.object.name", httpCachingClientSpanTagKeys));
     test:assertEquals(httpCachingClientSpanTags["src.object.name"], "ballerina/http/HttpCachingClient");
     test:assertTrue(containsTag("src.position", httpCachingClientSpanTagKeys));

--- a/ballerina-tests/zipkin-server-tests/tests/test.bal
+++ b/ballerina-tests/zipkin-server-tests/tests/test.bal
@@ -411,7 +411,7 @@ function testHttpClientSpanTags() returns error? {
     test:assertTrue(containsTag("src.function.name", httpClientSpanTagKeys));
     test:assertEquals(httpClientSpanTags["src.function.name"], "get");
     test:assertTrue(containsTag("src.module", httpClientSpanTagKeys));
-    test:assertEquals(httpClientSpanTags["src.module"], "ballerina/http:2.10.0");
+    test:assertEquals(httpClientSpanTags["src.module"], "ballerina/http:2.10.1");
     test:assertTrue(containsTag("src.object.name", httpClientSpanTagKeys));
     test:assertEquals(httpClientSpanTags["src.object.name"], "ballerina/http/HttpClient");
     test:assertTrue(containsTag("src.position", httpClientSpanTagKeys));

--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -34,3 +34,12 @@ reporterEndpoint="<TRACE_API>"  # Optional Configuration. This will override the
 agentHostname="127.0.0.1"  # Optional Configuration. Default value is localhost
 agentPort=9411             # Optional Configuration. Default value is 9411
 ```
+
+*Note*
+- If the `reporterEndpoint` is provided, the `agentHostname` and `agentPort` will be ignored.
+- If you want to pass a token for the reporter endpoint, configure the token as the environment variable `TRACE_API_TOKEN` and 
+  pass it to the `reporterEndpoint` as follows.
+```toml
+[ballerinax.zipkin]
+reporterEndpoint="<TRACE_API>?<TRACE_API_TOKEN_KEY>=$TRACE_API_TOKEN"
+```

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 # under the License.
 
 group=org.ballerinalang
-version=0.8.0-SNAPSHOT
+version=0.8.1-SNAPSHOT
 ballerinaLangVersion=2201.8.0-20230726-145300-b2bdf796
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/native/src/main/java/io/ballerina/observe/trace/zipkin/ZipkinTracerProvider.java
+++ b/native/src/main/java/io/ballerina/observe/trace/zipkin/ZipkinTracerProvider.java
@@ -64,6 +64,10 @@ public class ZipkinTracerProvider implements TracerProvider {
         String reporterEndpoint;
         if (!Objects.equals(String.valueOf(reporterEndpointUrl), "")) {
             reporterEndpoint = String.valueOf(reporterEndpointUrl);
+            if (reporterEndpoint.contains("$TRACE_API_TOKEN")) {
+                String token = System.getenv("TRACE_API_TOKEN");
+                reporterEndpoint = reporterEndpoint.replaceAll("\\$TRACE_API_TOKEN", token);
+            }
         } else {
             reporterEndpoint = APPLICATION_LAYER_PROTOCOL + "://" +
                     agentHostname + ":" + agentPort + "/api/v2/spans";


### PR DESCRIPTION
## Purpose
Currently, users have to pass the trace api token in the `reporterEndpoint` configuration and it may lead to security issues. This will provide the user the capability of passing the trace API token with an environment variable named as `TRACE_API_TOKEN`. Therefore users do not need to pass the trace api token with trace api URL anymore.

## Goals
Reduce security issues while using zipkin library.

### Fixes #5